### PR TITLE
Fix #6

### DIFF
--- a/result_group.go
+++ b/result_group.go
@@ -36,9 +36,14 @@ func (g *group) mergeResult(r *Result) {
 		return
 	}
 
+	// initialize KeyVal
 	if g.result == nil {
 		g.result = &Result{
 			KeyVal: make(map[string]interface{}),
+		}
+	} else {
+		if g.result.KeyVal == nil {
+			g.result.KeyVal = make(map[string]interface{})
 		}
 	}
 


### PR DESCRIPTION
Merge result keyval map when concurrent steps. If concurrent steps, the first error returned cancels the whole stage, result.Error returns the first received result's error